### PR TITLE
Fixed Honeypots Being Processed as Normal Shares

### DIFF
--- a/FSRM-Anti-ransomware.ps1
+++ b/FSRM-Anti-ransomware.ps1
@@ -557,7 +557,7 @@ Process
 			# since we're never going to apply a drive level screen to C: we need to apply the screen template to all shares on C: except those under C:\Windows
 			# this is an arbitrary decision on my part, recode as necessary
 			Get-SmbShare | Select-Object -Property * | 
-			Where-Object {($_.Special -ne "True") -and ($_.ShareType -eq "FileSystemDirectory") -and ($_.Path -like "C:\*") -and ($_.Path -notlike "C:\Windows\*")} | 
+			Where-Object {($_.Special -ne "True") -and ($_.ShareType -eq "FileSystemDirectory") -and ($_.Path -like "C:\*") -and ($_.Path -notlike "C:\Windows\*") -and ($_.Path -notlike "$HoneyPotDirectoryNamePattern")} | 
 			ForEach-Object {If (-not (Get-FsrmFileScreen -Path $_.Path -ErrorAction SilentlyContinue)) {New-FsrmFileScreen -Path $_.Path -Template $RansomwareTemplateName}}
 			}
 
@@ -567,7 +567,7 @@ Process
 		If ($ApplyRansomewareScreenToShares)
 			{
 			Get-SmbShare | Select-Object -Property * | 
-			Where-Object {($_.Special -ne "True") -and ($_.ShareType -eq "FileSystemDirectory") -and ($_.Path -notlike "C:\Windows\*")} | 
+			Where-Object {($_.Special -ne "True") -and ($_.ShareType -eq "FileSystemDirectory") -and ($_.Path -notlike "C:\Windows\*") -and ($_.Path -notlike "$HoneyPotDirectoryNamePattern")} | 
 			ForEach-Object {If (-not (Get-FsrmFileScreen -Path $_.Path -ErrorAction SilentlyContinue)) {New-FsrmFileScreen -Path $_.Path -Template $RansomwareTemplateName}}
 			}
 		}


### PR DESCRIPTION
-and ($_.Path -notlike “$HoneyPotDirectoryNamePattern”)
Added to lines 560 and 570
Without this, my honeypot shares were being processed by the "normal" shares section, with ApplyRansomewareScreenToShares. The honeypots were processed here instead of the honeypot section and given the RansomwareFnamesAndExtsCheck instead of RansomwareHoneyPotCheck.